### PR TITLE
feat: 試合ページの文字列の設定

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,0 +1,5 @@
+export const config = {
+  match: {
+    matchSeconds: 180,
+  },
+};

--- a/src/config/lang/lang.ts
+++ b/src/config/lang/lang.ts
@@ -3,7 +3,7 @@ type Lang = Record<string, string | Record<string, string>>;
 export const lang = {
   match: {
     leaveBase: "松江エリアを出た",
-    overMiddle: "中間線を越えた",
+    overMiddle: "中間点を越えた",
     enterDistination: "金星エリアに入った",
     placeBall: "ボールを金星エリアに置いた",
     returnBase: "松江エリアに戻った",

--- a/src/config/lang/lang.ts
+++ b/src/config/lang/lang.ts
@@ -1,4 +1,4 @@
-type Lang = Record<string, Record<string, string>>;
+type Lang = Record<string, string | Record<string, string>>;
 
 export const lang = {
   match: {

--- a/src/config/lang/lang.ts
+++ b/src/config/lang/lang.ts
@@ -1,0 +1,13 @@
+type Lang = Record<string, Record<string, string>>;
+
+export const lang = {
+  match: {
+    leaveBase: "松江エリアを出た",
+    overMiddle: "中間線を越えた",
+    enterDistination: "金星エリアに入った",
+    placeBall: "ボールを金星エリアに置いた",
+    returnBase: "松江エリアに戻った",
+    goal: "ゴール",
+    numberOfBall: "雲粒子の数",
+  },
+} satisfies Lang;

--- a/src/config/rule/rule.ts
+++ b/src/config/rule/rule.ts
@@ -1,4 +1,4 @@
-import { PointState, PointTable } from "./point";
+import { PointState, PointTable } from "../../utils/match/point";
 
 export const actions = [
   "multiWalk",

--- a/src/pages/match.tsx
+++ b/src/pages/match.tsx
@@ -20,12 +20,13 @@ import { Judge } from "../utils/match/judge";
 import { useForceReload } from "../hooks/useForceReload";
 import { Team } from "../utils/match/team";
 import { lang } from "../config/lang/lang";
+import { config } from "../config/config";
 
 type TimerState = "Initial" | "Started" | "Finished";
 
 export const Match = () => {
   const { id } = useParams();
-  const matchTimeSec = 300;
+  const matchTimeSec = config.match.matchSeconds;
   const [timerState, setTimerState] = useState<TimerState>("Initial");
   const { start, pause, resume, isRunning, totalSeconds } = useTimer({
     expiryTimestamp: expiryTimestamp(matchTimeSec),

--- a/src/pages/match.tsx
+++ b/src/pages/match.tsx
@@ -19,6 +19,7 @@ import { expiryTimestamp, parseSeconds } from "../utils/time";
 import { Judge } from "../utils/match/judge";
 import { useForceReload } from "../hooks/useForceReload";
 import { Team } from "../utils/match/team";
+import { lang } from "../config/lang/lang";
 
 type TimerState = "Initial" | "Started" | "Finished";
 
@@ -118,7 +119,7 @@ const PointControls = (props: {
 }) => {
   const [minBallCount, maxBallCount] = [0, 3] as const;
   const [ballCount, setBallCount] = useState(0);
-  useEffect(() => props.onChange(), [props]);
+  useEffect(props.onChange, []);
 
   const decrement = () => {
     if (ballCount == minBallCount) return;
@@ -143,7 +144,7 @@ const PointControls = (props: {
           props.onChange();
         }}
       >
-        松江エリアを出た
+        {lang.match.leaveBase}
       </ControlButton>
       <ControlButton
         color={props.color}
@@ -152,7 +153,7 @@ const PointControls = (props: {
           props.onChange();
         }}
       >
-        中間線を越えた
+        {lang.match.overMiddle}
       </ControlButton>
       <ControlButton
         color={props.color}
@@ -161,7 +162,7 @@ const PointControls = (props: {
           props.onChange();
         }}
       >
-        金星エリアに入った
+        {lang.match.enterDistination}
       </ControlButton>
       <ControlButton
         color={props.color}
@@ -170,7 +171,7 @@ const PointControls = (props: {
           props.onChange();
         }}
       >
-        ボールを金星エリアに置いた
+        {lang.match.placeBall}
       </ControlButton>
       <ControlButton
         color={props.color}
@@ -179,7 +180,7 @@ const PointControls = (props: {
           props.onChange();
         }}
       >
-        松江エリアに戻った
+        {lang.match.returnBase}
       </ControlButton>
       <ControlButton
         color={props.color}
@@ -188,13 +189,13 @@ const PointControls = (props: {
           props.onChange();
         }}
       >
-        ゴール{" "}
+        {lang.match.goal}{" "}
         {props.team.goalTimeSeconds != null &&
           parseSeconds(props.team.goalTimeSeconds)}
       </ControlButton>
       <Group>
         <Text size="1.2rem" c={props.color} style={{ flexGrow: 1 }}>
-          雲粒子の数:
+          {lang.match.numberOfBall}:
         </Text>
         <ActionIcon
           size="xl"

--- a/src/utils/match/point.ts
+++ b/src/utils/match/point.ts
@@ -1,4 +1,4 @@
-import { actions, pointTable } from "./rule";
+import { actions, pointTable } from "../../config/rule/rule";
 
 type Action = (typeof actions)[number];
 type PointCalculator =

--- a/src/utils/match/team.ts
+++ b/src/utils/match/team.ts
@@ -1,5 +1,5 @@
 import { Point, PointState } from "./point";
-import { initialPointState } from "./rule";
+import { initialPointState } from "../../config/rule/rule";
 
 export type SetGoalTimeSeconds = (goalTimeSec: number | null) => void;
 


### PR DESCRIPTION
- 試合ページの文字列が`src/config/lang/lang.ts`を参照するようになりました。
- 試合時間が`src/config/config.ts`を参照するようになりました。
- 採点ルールが`src/config/rule/rule.ts`を参照するようになりました。
- 今後も`src/config`以下に設定を生やす予定です。