### PR TITLE
feat: prettierでimport文をsortするようにした

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -8,5 +8,6 @@
   "singleQuote": false,
   "trailingComma": "es5",
   "tabWidth": 2,
-  "useTabs": false
+  "useTabs": false,
+  "plugins": ["prettier-plugin-organize-imports"]
 }

--- a/README.md
+++ b/README.md
@@ -36,4 +36,3 @@ see [poporonnet/kcms](https://github.com/poporonnet/kcms?tab=readme-ov-file#auth
 
 (C) 2023 Poporon Network & Other Contributors  
 MIT License
-

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "postcss-preset-mantine": "^1.11.1",
     "postcss-simple-vars": "^7.0.1",
     "prettier": "3.1.1",
+    "prettier-plugin-organize-imports": "^3.2.4",
     "typescript": "^5.2.2",
     "vite": "^5.0.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,6 +73,9 @@ devDependencies:
   prettier:
     specifier: 3.1.1
     version: 3.1.1
+  prettier-plugin-organize-imports:
+    specifier: ^3.2.4
+    version: 3.2.4(prettier@3.1.1)(typescript@5.3.3)
   typescript:
     specifier: ^5.2.2
     version: 5.3.3
@@ -2197,6 +2200,26 @@ packages:
         integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==,
       }
     engines: { node: ">= 0.8.0" }
+    dev: true
+
+  /prettier-plugin-organize-imports@3.2.4(prettier@3.1.1)(typescript@5.3.3):
+    resolution:
+      {
+        integrity: sha512-6m8WBhIp0dfwu0SkgfOxJqh+HpdyfqSSLfKKRZSFbDuEQXDDndb8fTpRWkUrX/uBenkex3MgnVk0J3b3Y5byog==,
+      }
+    peerDependencies:
+      "@volar/vue-language-plugin-pug": ^1.0.4
+      "@volar/vue-typescript": ^1.0.4
+      prettier: ">=2.0"
+      typescript: ">=2.9"
+    peerDependenciesMeta:
+      "@volar/vue-language-plugin-pug":
+        optional: true
+      "@volar/vue-typescript":
+        optional: true
+    dependencies:
+      prettier: 3.1.1
+      typescript: 5.3.3
     dev: true
 
   /prettier@3.1.1:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,9 @@
 import { RouterProvider } from "react-router-dom";
 
-import { router } from "./routes/router.tsx";
-import "./App.css";
-import "@mantine/core/styles.css";
 import { MantineProvider } from "@mantine/core";
+import "@mantine/core/styles.css";
+import "./App.css";
+import { router } from "./routes/router.tsx";
 
 const App = () => {
   return (

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,4 +1,4 @@
-import { AppShell, Title, Group } from "@mantine/core";
+import { AppShell, Group, Title } from "@mantine/core";
 import { Link } from "react-router-dom";
 
 export function Header() {

--- a/src/components/pointControls.tsx
+++ b/src/components/pointControls.tsx
@@ -1,9 +1,9 @@
 import {
-  MantineColor,
-  Flex,
-  Group,
   ActionIcon,
   Button,
+  Flex,
+  Group,
+  MantineColor,
   Text,
 } from "@mantine/core";
 import {
@@ -11,9 +11,9 @@ import {
   IconSquareChevronRightFilled,
 } from "@tabler/icons-react";
 import { useState } from "react";
+import { lang } from "../config/lang/lang";
 import { Team } from "../utils/match/team";
 import { parseSeconds } from "../utils/time";
-import { lang } from "../config/lang/lang";
 
 export const PointControls = (props: {
   color: MantineColor;

--- a/src/pages/match.tsx
+++ b/src/pages/match.tsx
@@ -1,12 +1,12 @@
-import { useState } from "react";
 import { Button, Divider, Flex, Paper, Text } from "@mantine/core";
-import { useTimer } from "react-timer-hook";
-import { expiryTimestamp, parseSeconds } from "../utils/time";
-import { Judge } from "../utils/match/judge";
-import { useForceReload } from "../hooks/useForceReload";
+import { useState } from "react";
 import { useLocation } from "react-router-dom";
+import { useTimer } from "react-timer-hook";
 import { PointControls } from "../components/pointControls";
 import { config } from "../config/config";
+import { useForceReload } from "../hooks/useForceReload";
+import { Judge } from "../utils/match/judge";
+import { expiryTimestamp, parseSeconds } from "../utils/time";
 
 type TimerState = "Initial" | "Started" | "Finished";
 export type TeamInfo = {

--- a/src/pages/matchList.tsx
+++ b/src/pages/matchList.tsx
@@ -1,6 +1,6 @@
 import { Box, Flex, Title } from "@mantine/core";
-import { MatchCard } from "../components/matchCard.tsx";
 import { useEffect, useState } from "react";
+import { MatchCard } from "../components/matchCard.tsx";
 import { TeamInfo } from "./match.tsx";
 
 // 考慮事項: 予選・決勝で同点の時のじゃんけんの入力をどうするか

--- a/src/routes/layout.tsx
+++ b/src/routes/layout.tsx
@@ -1,6 +1,6 @@
+import { AppShell } from "@mantine/core";
 import { Outlet } from "react-router-dom";
 import { Header } from "../components/header.tsx";
-import { AppShell } from "@mantine/core";
 
 export const Layout = () => (
   <AppShell

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -3,11 +3,11 @@ import {
   createBrowserRouter,
   createRoutesFromElements,
 } from "react-router-dom";
-import { Layout } from "./layout.tsx";
-import { Home } from "../pages/home.tsx";
 import { EntryList } from "../pages/entryList.tsx";
-import { MatchList } from "../pages/matchList.tsx";
+import { Home } from "../pages/home.tsx";
 import { Match } from "../pages/match.tsx";
+import { MatchList } from "../pages/matchList.tsx";
+import { Layout } from "./layout.tsx";
 
 export const router = createBrowserRouter(
   createRoutesFromElements(

--- a/src/utils/match/team.ts
+++ b/src/utils/match/team.ts
@@ -1,5 +1,5 @@
-import { Point, PointState } from "./point";
 import { initialPointState } from "../../config/rule/rule";
+import { Point, PointState } from "./point";
 
 export type SetGoalTimeSeconds = (goalTimeSec: number | null) => void;
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,5 @@
-import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
+import { defineConfig } from "vite";
 
 // https://vitejs.dev/config/
 export default defineConfig({


### PR DESCRIPTION
- [拡張機能](https://github.com/simonhaenisch/prettier-plugin-organize-imports)を導入
- その後 `pnpm format` を実行