### PR TITLE
fix: 先ゴールのルール計算の修正

### DIFF
--- a/src/config/rule/rule.ts
+++ b/src/config/rule/rule.ts
@@ -55,5 +55,5 @@ export const premise = {
   placeBall: () => true,
   returnBase: () => true,
   bringBall: () => true,
-  firstGoal: () => true,
+  firstGoal: (premiseState) => premiseState.matchInfo?.matchType === "final",
 } satisfies Premise;


### PR DESCRIPTION
- 「先にゴールしたチームに加点」を決勝戦でのみ行うようにしました。