### PR TITLE
fix: CI用テストを修正

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,15 +19,6 @@ jobs:
         with:
           bun-version: latest
 
-      - name: Cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/install/cache
-          key: ${{ runner.os }}-test-${{ hashFiles('**/bun.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
-
       - name: Install dependencies
         run: bun install
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,35 @@
+name: Test
+
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
+      - name: Cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/install/cache
+          key: ${{ runner.os }}-test-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Test
+        run: bun test:ci

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview",
     "format": "prettier --write .",
     "test": "vitest --watch --ui --coverage.enabled=true",
-    "test:ci": "vitest --coverage.enabled=true --ci"
+    "test:ci": "vitest run --coverage.enabled=true"
   },
   "dependencies": {
     "@mantine/carousel": "^7.3.1",


### PR DESCRIPTION
Close #72 

- `vitest run`で単発実行(watchモードにしない)
- `--ci`オプションは存在しないため削除
- ついでにworkflowを整備